### PR TITLE
Portrait layout on mobile has overlapping elements

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,38 +1,16 @@
-.App {
-  text-align: center;
+.drawerOpen {
+  margin: 0 2rem;
+  width: calc(100% - 4rem);
 }
 
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
+.drawerClosed {
+  margin: 0 2rem;
+  width: calc(100% - 4rem);
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
-}
-
-.App-header {
-  background-color: #282c34;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
-}
-
-.App-link {
-  color: #61dafb;
-}
-
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
+@media only screen and (min-width: 768px) {
+  .drawerOpen {
+    margin: 0 2rem 0 calc(17rem + 64px);
+    width: calc(100% - 19rem - 64px);
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,5 @@
+import "./App.css";
+
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import queryString from "query-string";

--- a/src/layouts/Account.css
+++ b/src/layouts/Account.css
@@ -1,12 +1,12 @@
-.paper {
+.Account .paper {
   padding: 0 1rem 0.5rem 1rem;
 }
 
-.logoPreview {
+.Account .logoPreview {
   max-height: 10rem;
   max-width: 75%;
 }
 
-input[type="file"] {
+.Account input[type="file"] {
   display: none;
 }

--- a/src/layouts/Account.tsx
+++ b/src/layouts/Account.tsx
@@ -20,7 +20,6 @@ import Switch from "@material-ui/core/Switch";
 import TextField from "@material-ui/core/TextField";
 
 import { clearSnackbar, deleteAccount, patchAccount, updateAccount, updateLogo } from "../actions";
-import { Statics as _C } from "../classes";
 import { Header, Sidebar } from "../components";
 import { api } from "../consts";
 import { Account as IAccount, Action, AxiosError, InputState, Response, Snackbar as ISnackbar } from "../interfaces";
@@ -313,13 +312,12 @@ class Account extends Component<AccountProps, AccountState> {
       deleteDisabled,
     } = this.state;
     const logoPreview = logo.file ? <img className="logoPreview" src={logo.data} alt="Your business' logo" /> : null;
-    const gridStyle = _C.GridWidth(showDrawer);
     return (
       <>
         <Header />
         <Sidebar />
-        <Grid style={gridStyle} spacing={4} container>
-          <Grid item md={4}>
+        <Grid className={(showDrawer ? "Account drawerOpen" : "Account drawerClosed")} spacing={4} container>
+          <Grid item lg={4} md={6}>
             <Paper className="paper" elevation={3}>
               <h2>Account Details</h2>
               <form onSubmit={this._accountSubmit}>
@@ -409,7 +407,7 @@ class Account extends Component<AccountProps, AccountState> {
               </form>
             </Paper>
           </Grid>
-          <Grid item md={4}>
+          <Grid item lg={4} md={6}>
             <Paper className="paper" elevation={3}>
               <h2>Update Logo</h2>
               {logoPreview}
@@ -440,7 +438,7 @@ class Account extends Component<AccountProps, AccountState> {
               </form>
             </Paper>
           </Grid>
-          <Grid item md={4}>
+          <Grid item lg={4} md={6}>
             <Paper className="paper" elevation={3}>
               <h2>Change Password</h2>
               <form onSubmit={this._passwordSubmit}>

--- a/src/layouts/Analytics.css
+++ b/src/layouts/Analytics.css
@@ -8,7 +8,7 @@
   margin: 0;
 }
 
-.MuiPaper-root div.footer {
+.Analytics .MuiPaper-root div.footer {
   margin-top: 1rem;
   border-top: solid thin gainsboro;
   font-size: 75%;

--- a/src/layouts/Analytics.tsx
+++ b/src/layouts/Analytics.tsx
@@ -10,7 +10,6 @@ import Paper from "@material-ui/core/Paper";
 import { Bar, BarChart, CartesianGrid, Cell, Pie, PieChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 
 import { checkSession, fetchStatistics } from "../actions";
-import { Statics as _C } from "../classes";
 import { Action, Statistics } from "../interfaces";
 
 class Analytics extends Component<AnalyticsProps, AnalyticsState> {
@@ -21,7 +20,6 @@ class Analytics extends Component<AnalyticsProps, AnalyticsState> {
 
   render = () => {
     const { showDrawer, statistics } = this.props;
-    const gridStyle = _C.GridWidth(showDrawer);
     const todayString = new Date().toDateString();
     const hourData = statistics.byHour.map((rowData, i) => {
       const hours = ["12am", "1am", "2am", "3am", "4am", "5am", "6am", "7am", "8am", "9am", "10am", "11am", "12pm", "1pm", "2pm", "3pm", "4pm", "5pm", "6pm", "7pm", "8pm", "9pm", "10pm", "11pm"];
@@ -59,8 +57,8 @@ class Analytics extends Component<AnalyticsProps, AnalyticsState> {
       <>
         <Header />
         <Sidebar />
-        <Grid className="Analytics" style={gridStyle} spacing={4} justify={"center"} container>
-          <Grid item md={6}>
+        <Grid className={(showDrawer ? "Analytics drawerOpen" : "Analytics drawerClosed")} spacing={4} justify={"flex-start"} container>
+          <Grid item lg={6} md={12}>
             <Paper elevation={3} square>
               <h2>Visitors by Hour</h2>
               <ResponsiveContainer width="100%" height={250}>
@@ -75,7 +73,7 @@ class Analytics extends Component<AnalyticsProps, AnalyticsState> {
               <div className="footer">Based on previous 28 days of visitor data.</div>
             </Paper>
           </Grid>
-          <Grid item md={6}>
+          <Grid item lg={6} md={12}>
             <Paper elevation={3} square>
               <Paper elevation={3} square>
                 <h2>Visitors by Day of Week</h2>
@@ -92,14 +90,14 @@ class Analytics extends Component<AnalyticsProps, AnalyticsState> {
               </Paper>
             </Paper>
           </Grid>
-          <Grid item md={3}>
+          <Grid item lg={4} md={6} sm={12}>
             <Paper elevation={3} square>
               <h2>Visitors Today</h2>
               <p className="large">{statistics.today}</p>
               <div className="footer">Data for {todayString}.</div>
             </Paper>
           </Grid>
-          <Grid item md={3}>
+          <Grid item lg={4} md={6} sm={12}>
             <Paper elevation={3} square>
               <h2>Returning Visitors</h2>
               <ResponsiveContainer width="100%" height={110}>
@@ -125,7 +123,7 @@ class Analytics extends Component<AnalyticsProps, AnalyticsState> {
               <div className="footer">Based on previous 28 days of visitor data.</div>
             </Paper>
           </Grid>
-          <Grid item md={6}>
+          <Grid item lg={4} md={6} sm={12}>
             <Paper elevation={3} square>
               <h2>API Requests</h2>
               <ResponsiveContainer width="100%" height={apiGraphHeight}>

--- a/src/layouts/ConditionsOfEntry.css
+++ b/src/layouts/ConditionsOfEntry.css
@@ -1,0 +1,7 @@
+.ConditionsOfEntry .paper {
+  padding: 0 1rem 0.5rem 1rem;
+}
+
+.ConditionsOfEntry button {
+  margin-top: 0.5rem;
+}

--- a/src/layouts/ConditionsOfEntry.tsx
+++ b/src/layouts/ConditionsOfEntry.tsx
@@ -1,3 +1,5 @@
+import "./ConditionsOfEntry.css";
+
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { AxiosResponse } from "axios";
@@ -10,7 +12,6 @@ import Snackbar from "@material-ui/core/Snackbar";
 import TextField from "@material-ui/core/TextField";
 
 import { addCheckItem, fetchChecklist } from "../actions";
-import { Statics as _C } from "../classes";
 import { ConditionsOfEntryRow, Header, Sidebar } from "../components";
 import { api } from "../consts";
 import { Action, ChecklistItem, InputState, Response } from "../interfaces";
@@ -98,14 +99,13 @@ class ConditionsOfEntry extends Component<ConditionsOfEntryProps, ConditionsOfEn
     const { checklist, showDrawer } = this.props;
     const { message, newItem } = this.state;
     const conditionList = checklist.map((item) => <ConditionsOfEntryRow id={item.id} text={item.statement} key={item.id} />);
-    const gridStyle = _C.GridWidth(showDrawer);
     return (
       <>
         <Header />
         <Sidebar />
-        <Grid style={gridStyle} spacing={4} container>
+        <Grid className={(showDrawer ? "ConditionsOfEntry drawerOpen" : "ConditionsOfEntry drawerClosed")} spacing={4} container>
           <Grid item md={12}>
-            <Paper className="paper" elevation={3}>
+            <Paper className="paper" elevation={3} square>
               <h2>Conditions of Entry</h2>
               {conditionList}
               <form onSubmit={this._formSubmit}>
@@ -114,7 +114,6 @@ class ConditionsOfEntry extends Component<ConditionsOfEntryProps, ConditionsOfEn
                   fullWidth
                   name="newItem"
                   label={newItem.label}
-                  className="input"
                   value={newItem.value}
                   error={newItem.error}
                   onChange={this._formChange}

--- a/src/layouts/DataRequest.css
+++ b/src/layouts/DataRequest.css
@@ -7,5 +7,9 @@
 }
 
 .DataRequest button {
-  margin-top: 0.5rem;
+  margin: 0.5rem;
+}
+
+.DataRequest .MuiPaper-root {
+  padding: 0 0.5rem;
 }

--- a/src/layouts/DataRequest.tsx
+++ b/src/layouts/DataRequest.tsx
@@ -10,7 +10,6 @@ import Paper from "@material-ui/core/Paper";
 import Snackbar from "@material-ui/core/Snackbar";
 import TextField from "@material-ui/core/TextField";
 
-import { Statics as _C } from "../classes";
 import { Header, Sidebar } from "../components";
 import { api } from "../consts";
 import { checkSession } from "../actions";
@@ -175,7 +174,6 @@ class DataRequest extends Component<DataRequestProps, DataRequestState> {
   render = () => {
     const { showDrawer } = this.props;
     const { phone, date, authContact, password, message, phoneResponse } = this.state;
-    const gridStyle = _C.GridWidth(showDrawer);
     const phoneContent = phoneResponse.ready ? (
       <>
         <p>Results for {phone.value}:</p>
@@ -216,9 +214,9 @@ class DataRequest extends Component<DataRequestProps, DataRequestState> {
       <>
         <Header />
         <Sidebar />
-        <Grid className="DataRequest" style={gridStyle} justify="center" spacing={4} container>
+        <Grid className={(showDrawer ? "DataRequest drawerOpen" : "DataRequest drawerClosed")} justify="center" spacing={4} container>
           <Grid item md={6}>
-            <Paper elevation={3} className="paper" square>
+            <Paper elevation={3} square>
               <h2>Data Request</h2>
               <p>
                 These forms permit the request for the contact data of visitors to your business. As per the CovidVault privacy
@@ -250,7 +248,7 @@ class DataRequest extends Component<DataRequestProps, DataRequestState> {
           </Grid>
           <Grid item md={6}>
             <Grid item md={12}>
-              <Paper elevation={3} className="paper" square>
+              <Paper elevation={3} square>
                 <h3>Request Data by Date</h3>
                 <form onSubmit={this._dateSubmit}>
                   <TextField
@@ -282,7 +280,7 @@ class DataRequest extends Component<DataRequestProps, DataRequestState> {
               </Paper>
             </Grid>
             <Grid item md={12}>
-              <Paper elevation={3} className="paper" square>
+              <Paper elevation={3} square>
                 <h3>Request Data by Phone Number</h3>
                 {phoneContent}
               </Paper>

--- a/src/layouts/FollowThru.css
+++ b/src/layouts/FollowThru.css
@@ -1,21 +1,29 @@
-.row {
+.FollowThru .paper {
+  padding: 0 1rem 0.5rem 1rem;
+}
+
+.FollowThru .row {
   margin-top: 1rem;
 }
 
-.row > div {
+.FollowThru .row > div {
  width: calc(50% - 0.5rem);
 }
 
-.row > div:last-child {
+.FollowThru .row > div:last-child {
   margin-left: 1rem;
 }
 
-.row > button {
+.FollowThru .row > button {
   margin-top: 0.5rem;
   margin-left: 1rem;
 }
 
-.datePickerRow > div > label {
+.FollowThru .datePickerRow > div > label {
   color: #3f51b5;
   transform: translate(0, 1.5px) scale(0.75) !important;
+}
+
+.FollowThru input[type="file"] {
+  display: none;
 }

--- a/src/layouts/FollowThru.tsx
+++ b/src/layouts/FollowThru.tsx
@@ -14,7 +14,6 @@ import TextField from "@material-ui/core/TextField";
 
 import { addFollowThru, clearSnackbar, fetchFollowThru } from "../actions";
 import { FollowThruRow, Header, Sidebar } from "../components";
-import { Statics as _C } from "../classes";
 import { api } from "../consts";
 import { Action, AxiosError, FollowThru as IFollowThru, InputState, Response } from "../interfaces";
 
@@ -217,14 +216,13 @@ class FollowThru extends Component<FollowThruProps, FollowThruState> {
       ) : (
         <p>No promotional links have been added.</p>
       );
-    const gridStyle = _C.GridWidth(showDrawer);
     return (
       <>
         <Header />
         <Sidebar />
-        <Grid style={gridStyle} spacing={4} container>
+        <Grid className={(showDrawer ? "FollowThru drawerOpen" : "FollowThru drawerClosed")} spacing={4} container>
           <Grid item md={8}>
-            <Paper className="paper" elevation={3}>
+            <Paper className="paper" elevation={3} square>
               <h2>Add New Link</h2>
               <form onSubmit={this._addFollowThru}>
                 <Box className="row">
@@ -293,13 +291,13 @@ class FollowThru extends Component<FollowThruProps, FollowThruState> {
             </Paper>
           </Grid>
           <Grid item md={4}>
-            <Paper className="paper" elevation={3}>
+            <Paper className="paper" elevation={3} square>
               <h2>Preview</h2>
               <p>Coming in a future update.</p>
             </Paper>
           </Grid>
           <Grid item md={8}>
-            <Paper className="paper" elevation={3}>
+            <Paper className="paper" elevation={3} square>
               <h2>Promotional Links</h2>
               {linkList}
             </Paper>

--- a/src/layouts/ManualEntry.tsx
+++ b/src/layouts/ManualEntry.tsx
@@ -18,7 +18,6 @@ import TextField from "@material-ui/core/TextField";
 import TickIcon from "@material-ui/icons/Check";
 
 import { checkSession } from "../actions";
-import { Statics as _C } from "../classes";
 import { Header, Sidebar } from "../components";
 import { api } from "../consts";
 import { Action, Message, Response } from "../interfaces";
@@ -122,7 +121,6 @@ class ManualEntry extends Component<ManualEntryProps, ManualEntryState> {
   render = () => {
     const { showDrawer } = this.props;
     const { date, message, visitors } = this.state;
-    const gridStyle = _C.GridWidth(showDrawer);
     const entryRows = visitors.map((row, i) => {
       const icon = row.complete ? <TickIcon /> : <DeleteIcon />;
       return (
@@ -158,8 +156,8 @@ class ManualEntry extends Component<ManualEntryProps, ManualEntryState> {
       <>
         <Header />
         <Sidebar />
-        <Grid className="ManualEntry" style={gridStyle} justify={"center"} spacing={4} container>
-          <Grid item md={4}>
+        <Grid className={(showDrawer ? "ManualEntry drawerOpen" : "ManualEntry drawerClosed")} justify={"center"} spacing={4} container>
+          <Grid item lg={4} md={12}>
             <Paper elevation={3} className="paper" square>
               <h2>Manual Data Entry</h2>
               <p>
@@ -176,7 +174,7 @@ class ManualEntry extends Component<ManualEntryProps, ManualEntryState> {
               <p>Make sure to correctly set the date before submitting!</p>
             </Paper>
           </Grid>
-          <Grid item md={8}>
+          <Grid item lg={8} md={12}>
             <Paper elevation={3} className="paper" square>
               <h2>&nbsp;</h2>
               <form onSubmit={this._formSubmit}>


### PR DESCRIPTION
Fixes #26

Note: for device screen widths of less than 768px, the menu will deliberately overlap content. Closing the menu will allow the content behind to become visible. The menu is toggled via the hamburger button at the top-left of the screen.